### PR TITLE
feat(sdk): implement wrappers for all endpoints

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const FlowSchema = z.object({
+    ty: z.literal('flow'),
+    ts: z.coerce.date(),
+    flow: z.number().int().nonnegative(),
+});
+export type Flow = z.infer<typeof FlowSchema>;
+
+export const LeakSchema = z.object({
+    ty: z.literal('leak'),
+    ts: z.coerce.date(),
+});
+export type Leak = z.infer<typeof LeakSchema>;
+
+export const ControlSchema = z.object({
+    ty: z.literal('control'),
+    ts: z.coerce.date(),
+    shutdown: z.boolean(),
+});
+export type Control = z.infer<typeof ControlSchema>;
+
+export const UserMessageSchema = z.union([
+    FlowSchema,
+    LeakSchema,
+    ControlSchema,
+]);
+export type UserMessage = z.infer<typeof UserMessageSchema>;

--- a/src/sdk/api.ts
+++ b/src/sdk/api.ts
@@ -4,6 +4,31 @@ import { InvalidSession, UnexpectedStatusCode } from './error.ts';
 
 /**
  * Assuming that the user has already logged in (i.e., there exists a valid session ID
+ * in the cookie store), this endpoint sends a request to the Cloud to reset or manually
+ * bypass a locked unit (i.e., "closed valve").
+ *
+ * Returns `true` if the unit was previously locked. Returns `false` if the device is
+ * already unlocked (due to a previous invocation for example).
+ */
+export async function requestReset(): Promise<boolean> {
+    const { status } = await fetch('/api/reset', {
+        method: 'POST',
+        credentials: 'include',
+    });
+    switch (status) {
+        case StatusCodes.OK:
+            return true;
+        case StatusCodes.ACCEPTED:
+            return false;
+        case StatusCodes.UNAUTHORIZED:
+            throw new InvalidSession();
+        default:
+            throw new UnexpectedStatusCode(status);
+    }
+}
+
+/**
+ * Assuming that the user has already logged in (i.e., there exists a valid session ID
  * in the cookie store), this endpoint sends a request to the Cloud to shut down the
  * device associated with the session.
  *


### PR DESCRIPTION
Supersedes and closes #13.

This PR implements the full client-side SDK for the Cloud API. The highlight feature is the wrapper for the `/api/metrics?start={Date}` SSE endpoint. The way I implemented the wrapper involves two four steps:

1. Open the connection. Reject the `Promise` if it fails here.
2. Receive only the first message (referred to as `init`), which is a JSON object of type `UserMessage[]`. This array contains all the data points since the `start` query parameter.
3. Set up the event listeners that invoke a `callback` for each new `UserMessage` object that follows.
4. Resolve the `Promise` by return `init`.

# Example

```ts
import { getMetrics } from 'sdk/api.ts';

const { init, close } = await getMetrics(message => {
    // Log each new message after the `init`
    console.log(message);

    // Since the event stream is multiplexed, we need to "match"
    // against the discriminant of the union, which is `UserMessage.ty`.
    // In the Svelte side, we multiplex the raw data into dedicated
    // async stores. That will be done in a future PR.
    switch (message.ty) {
        case 'flow': break;    // TODO
        case 'leak': break;    // TODO
        case 'control': break; // TODO
        default: throw new Error('unexpected message type');
    }
});

// Print out the initial data points
console.log(init);

// Close the SSE connection if you want
close();
```