### PR TITLE
feat(sdk)!: update API wrappers according to new specifications

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,28 +1,28 @@
 import { z } from 'zod';
 
-export const FlowSchema = z.object({
+export const PingSchema = z.object({
     ty: z.literal('flow'),
     ts: z.coerce.date(),
     flow: z.number().int().nonnegative(),
+    leak: z.boolean(),
 });
-export type Flow = z.infer<typeof FlowSchema>;
+export type Ping = z.infer<typeof PingSchema>;
 
-export const LeakSchema = z.object({
-    ty: z.literal('leak'),
+export const OpenSchema = z.object({
+    ty: z.literal('open'),
     ts: z.coerce.date(),
 });
-export type Leak = z.infer<typeof LeakSchema>;
+export type Open = z.infer<typeof OpenSchema>;
 
-export const ControlSchema = z.object({
-    ty: z.literal('control'),
+export const CloseSchema = z.object({
+    ty: z.literal('close'),
     ts: z.coerce.date(),
-    shutdown: z.boolean(),
 });
-export type Control = z.infer<typeof ControlSchema>;
+export type Close = z.infer<typeof CloseSchema>;
 
 export const UserMessageSchema = z.discriminatedUnion('ty', [
-    FlowSchema,
-    LeakSchema,
-    ControlSchema,
+    PingSchema,
+    OpenSchema,
+    CloseSchema,
 ]);
 export type UserMessage = z.infer<typeof UserMessageSchema>;

--- a/src/sdk/auth.ts
+++ b/src/sdk/auth.ts
@@ -2,10 +2,11 @@ import { StatusCodes } from 'http-status-codes';
 
 import { assert } from '../assert.ts';
 import { BadInput, UnexpectedStatusCode } from './error.ts';
+import { Command } from '../models/command.ts';
 
 export interface Session {
     mac: ArrayBuffer;
-    shutdown: boolean;
+    request: Command;
 }
 
 /**
@@ -19,9 +20,11 @@ export async function getSession(): Promise<Session | null> {
     assert(mac.byteLength === 6);
     switch (res.status) {
         case StatusCodes.OK:
-            return { mac, shutdown: false };
-        case StatusCodes.SERVICE_UNAVAILABLE:
-            return { mac, shutdown: true };
+            return { mac, request: Command.None };
+        case StatusCodes.ACCEPTED:
+            return { mac, request: Command.Open };
+        case StatusCodes.NO_CONTENT:
+            return { mac, request: Command.Close };
         case StatusCodes.UNAUTHORIZED:
             return null;
         default:


### PR DESCRIPTION
drippy-iot/cloud#6 merges the leak detection and the flow reporter endpoints into one. We thus adjust the SSE stream's data assumptions accordingly. Additionally, the PR also changes the status codes for session management. We handle those breaking changes here as well.