### PR TITLE
feat: update `UserMessage` to include bypass event

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -20,9 +20,16 @@ export const CloseSchema = z.object({
 });
 export type Close = z.infer<typeof CloseSchema>;
 
+export const BypassSchema = z.object({
+    ty: z.literal('bypass'),
+    ts: z.coerce.date(),
+});
+export type Bypass = z.infer<typeof CloseSchema>;
+
 export const UserMessageSchema = z.discriminatedUnion('ty', [
     PingSchema,
     OpenSchema,
     CloseSchema,
+    BypassSchema,
 ]);
 export type UserMessage = z.infer<typeof UserMessageSchema>;


### PR DESCRIPTION
In response to drippy-iot/cloud#7, we include the new bypass event as a possible `UserMessage`.